### PR TITLE
Fix/knp components version

### DIFF
--- a/app/Resources/views/User/user-list.html.twig
+++ b/app/Resources/views/User/user-list.html.twig
@@ -16,7 +16,7 @@
                 <thead>
                 <tr>
                     <th{% if pagination.isSorted('firstName') %} class="sorted {{ pagination.getDirection() }}"{% endif %}>{{ knp_pagination_sortable(pagination, 'First name', 'firstName') }}</th>
-                    <th{% if pagination.isSorted('structure') %} class="sorted {{ pagination.getDirection() }}"{% endif %}>{{ knp_pagination_sortable(pagination, 'Structure', 'structure') }}</th>
+                    <th{% if pagination.isSorted('structure.name') %} class="sorted {{ pagination.getDirection() }}"{% endif %}>{{ knp_pagination_sortable(pagination, 'Structure', 'structure.name') }}</th>
                 </tr>
                 </thead>
                 <tbody>

--- a/composer.lock
+++ b/composer.lock
@@ -1248,16 +1248,16 @@
         },
         {
             "name": "knplabs/knp-components",
-            "version": "v1.3.9",
+            "version": "v1.3.10",
             "source": {
                 "type": "git",
                 "url": "https://github.com/KnpLabs/knp-components.git",
-                "reference": "f0f830361ff0ee83ea5c5ffe49b429d2b0ff4266"
+                "reference": "fc1755ba2b77f83a3d3c99e21f3026ba2a1429be"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/KnpLabs/knp-components/zipball/f0f830361ff0ee83ea5c5ffe49b429d2b0ff4266",
-                "reference": "f0f830361ff0ee83ea5c5ffe49b429d2b0ff4266",
+                "url": "https://api.github.com/repos/KnpLabs/knp-components/zipball/fc1755ba2b77f83a3d3c99e21f3026ba2a1429be",
+                "reference": "fc1755ba2b77f83a3d3c99e21f3026ba2a1429be",
                 "shasum": ""
             },
             "require": {
@@ -1310,7 +1310,7 @@
                 "pager",
                 "paginator"
             ],
-            "time": "2018-08-03T08:37:27+00:00"
+            "time": "2018-09-11T07:54:48+00:00"
         },
         {
             "name": "knplabs/knp-paginator-bundle",

--- a/src/AppBundle/Entity/Structure.php
+++ b/src/AppBundle/Entity/Structure.php
@@ -55,7 +55,7 @@ class Structure {
 	}
 	
 	public function __toString() {
-		return (string) $this->getName();
+		return $this->getName();
 	}
 
     /**


### PR DESCRIPTION
- Reverted commit https://github.com/sirion89/knppaginatorexample/commit/2adc0dbcdb35dffe75437392b30d3a99f54f794b
- Update knp-components to [v1.3.10](https://github.com/KnpLabs/knp-components/releases/tag/v1.3.10)

You're now able to sort when there's a `NULL` relation w/o making any changes to your code. The fix has been released in `v1.3.10`.